### PR TITLE
リーチによる点数変動をわかりやすく表示

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,18 @@
 import type { NextConfig } from "next";
+import path from "path";
+import { fileURLToPath } from "url";
+
+/** ホーム直下など別の lockfile があると Turbopack が誤ったルートを選ぶため、このプロジェクトを明示する */
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   output: "export",
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
   images: {
     unoptimized: true,
+  },
+  turbopack: {
+    root: projectRoot,
   },
 };
 

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -47,7 +47,7 @@ function GameContent() {
         let next: GameState;
         switch (action.type) {
           case "add-round":
-            next = addRound(prev, action.roundNum, action.honba, action.scores, action.kyotakuAfter);
+            next = addRound(prev, action.roundNum, action.honba, action.scores, action.kyotakuAfter, action.riichiSeats);
             break;
           case "delete-last-round":
             next = deleteLastRound(prev);
@@ -126,7 +126,7 @@ function GameContent() {
     }
   }, [game?.rounds.length]);
 
-  const handleSubmitScore = (data: { scores: number[]; kyotakuAfter: number }) => {
+  const handleSubmitScore = (data: { scores: number[]; kyotakuAfter: number; riichiSeats: number[] }) => {
     setSubmitting(true);
     const action: GameAction = {
       type: "add-round",
@@ -134,6 +134,7 @@ function GameContent() {
       honba,
       scores: data.scores,
       kyotakuAfter: data.kyotakuAfter,
+      riichiSeats: data.riichiSeats,
     };
 
     if (role === "host") {
@@ -332,10 +333,27 @@ function GameContent() {
                   key={`${round.roundNum}-${round.honba}`}
                   className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-sm dark:bg-gray-800"
                 >
-                  <span className="shrink-0 font-medium text-gray-600 dark:text-gray-300">
-                    {roundLabel(round.roundNum, pc)}
-                    {round.honba > 0 && ` ${round.honba}本`}
-                  </span>
+                  <div className="shrink-0">
+                    <span className="font-medium text-gray-600 dark:text-gray-300">
+                      {roundLabel(round.roundNum, pc)}
+                      {round.honba > 0 && ` ${round.honba}本`}
+                    </span>
+                    {round.riichiSeats && round.riichiSeats.length > 0 && (
+                      <div className="flex gap-1 mt-0.5">
+                        {round.riichiSeats.map((seat) => {
+                          const player = game.players.find((p) => p.seat === seat);
+                          return (
+                            <span
+                              key={seat}
+                              className="rounded-sm bg-amber-100 px-1 text-[10px] font-medium text-amber-700 dark:bg-amber-900 dark:text-amber-300"
+                            >
+                              {player?.name ?? `P${seat}`} R
+                            </span>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
                   <div className="flex items-center gap-3">
                     <div className="flex gap-2">
                       {game.players.map((player) => {

--- a/src/components/ScoreInputModal.tsx
+++ b/src/components/ScoreInputModal.tsx
@@ -21,6 +21,7 @@ type GamePlayer = {
 type SubmitData = {
   scores: number[];
   kyotakuAfter: number;
+  riichiSeats: number[];
 };
 
 type Props = {
@@ -124,7 +125,8 @@ export default function ScoreInputModal({
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    onSubmit({ scores: currentScores, kyotakuAfter: currentKyotakuAfter });
+    const submittedRiichiSeats = mode === "manual" ? [] : riichiSeats;
+    onSubmit({ scores: currentScores, kyotakuAfter: currentKyotakuAfter, riichiSeats: submittedRiichiSeats });
   };
 
   // リーチ選択UI（アガリ・流局共通）
@@ -455,25 +457,40 @@ export default function ScoreInputModal({
             点数変動
           </div>
           <div className="flex gap-2">
-            {players.map((player, i) => (
-              <div key={player.id} className="flex-1 text-center">
-                <div className="text-xs text-gray-500 truncate">
-                  {player.name}
+            {players.map((player, i) => {
+              const isRiichi = mode !== "manual" && riichiSeats.includes(player.seat);
+              const totalKyotaku = kyotaku + riichiSeats.length;
+              const collectsKyotaku = mode === "agari" && agariResult !== null && player.seat === winnerSeat && totalKyotaku > 0;
+              return (
+                <div key={player.id} className="flex-1 text-center">
+                  <div className="text-xs text-gray-500 truncate">
+                    {player.name}
+                  </div>
+                  <div
+                    className={`text-sm font-bold tabular-nums ${
+                      currentScores[i] > 0
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : currentScores[i] < 0
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-gray-400"
+                    }`}
+                  >
+                    {currentScores[i] > 0 ? "+" : ""}
+                    {currentScores[i].toLocaleString()}
+                  </div>
+                  {isRiichi && (
+                    <div className="text-[10px] text-amber-600 dark:text-amber-400">
+                      リーチ -1,000
+                    </div>
+                  )}
+                  {collectsKyotaku && (
+                    <div className="text-[10px] text-amber-600 dark:text-amber-400">
+                      供託 +{(totalKyotaku * 1000).toLocaleString()}
+                    </div>
+                  )}
                 </div>
-                <div
-                  className={`text-sm font-bold tabular-nums ${
-                    currentScores[i] > 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : currentScores[i] < 0
-                      ? "text-red-600 dark:text-red-400"
-                      : "text-gray-400"
-                  }`}
-                >
-                  {currentScores[i] > 0 ? "+" : ""}
-                  {currentScores[i].toLocaleString()}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
           {mode === "manual" && scoreTotal !== 0 && (
             <div className="mt-1 text-center text-xs font-medium text-red-600 dark:text-red-400">

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -12,6 +12,7 @@ export type Round = {
   roundNum: number;
   honba: number;
   scores: RoundScore[];
+  riichiSeats: number[];
 };
 
 export type GameState = {
@@ -50,6 +51,7 @@ export function addRound(
   honba: number,
   scores: number[],
   kyotakuAfter: number,
+  riichiSeats: number[] = [],
 ): GameState {
   const roundScores = state.players.map((p, i) => ({
     seat: p.seat,
@@ -58,7 +60,7 @@ export function addRound(
   return {
     ...state,
     kyotaku: kyotakuAfter,
-    rounds: [...state.rounds, { roundNum, honba, scores: roundScores }],
+    rounds: [...state.rounds, { roundNum, honba, scores: roundScores, riichiSeats }],
   };
 }
 

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -19,6 +19,7 @@ export type GameAction =
       honba: number;
       scores: number[];
       kyotakuAfter: number;
+      riichiSeats: number[];
     }
   | { type: "delete-last-round" }
   | { type: "finish-game" };


### PR DESCRIPTION
## Summary
- Round型・GameAction・SubmitDataに`riichiSeats`を追加し、各局のリーチ情報を記録
- スコア入力モーダルの点数変動プレビューにリーチ棒(-1,000)・供託回収(+X,000)の内訳を表示
- 局履歴にリーチ宣言者バッジを表示

Closes #1