### PR TITLE
fix: データ消失と複数端末同時入力の重複を修正 (close #3, close #4)

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -10,6 +10,8 @@ import {
   deleteLastRound,
   finishGame,
   getCurrentPoints,
+  saveState,
+  loadState,
 } from "@/lib/gameState";
 import { RoomHost, RoomGuest, type GameAction, type PeerRole } from "@/lib/peer";
 import ScoreInputModal from "@/components/ScoreInputModal";
@@ -71,13 +73,18 @@ function GameContent() {
     if (!roomId) return;
 
     if (role === "host") {
-      // ホスト: ゲーム作成 + PeerJS開始
-      const pc = Number(searchParams.get("pc") ?? "4");
-      const ip = Number(searchParams.get("ip") ?? "25000");
-      const rp = Number(searchParams.get("rp") ?? "30000");
-      const names = (searchParams.get("p") ?? "").split(",");
-
-      const initialState = createInitialState(roomId, pc, names, ip, rp);
+      // ホスト: localStorage から復元、なければ新規作成
+      const persisted = loadState(roomId);
+      let initialState: GameState;
+      if (persisted) {
+        initialState = persisted;
+      } else {
+        const pc = Number(searchParams.get("pc") ?? "4");
+        const ip = Number(searchParams.get("ip") ?? "25000");
+        const rp = Number(searchParams.get("rp") ?? "30000");
+        const names = (searchParams.get("p") ?? "").split(",");
+        initialState = createInitialState(roomId, pc, names, ip, rp);
+      }
       setGame(initialState);
 
       const host = new RoomHost({
@@ -98,7 +105,10 @@ function GameContent() {
 
       return () => host.destroy();
     } else {
-      // ゲスト: PeerJS接続
+      // ゲスト: 先に localStorage から復元して即表示
+      const persisted = loadState(roomId);
+      if (persisted) setGame(persisted);
+
       const guest = new RoomGuest({
         onStateUpdate: setGame,
         onAction: () => {},
@@ -115,6 +125,33 @@ function GameContent() {
       return () => guest.destroy();
     }
   }, [roomId, role, searchParams, handleAction]);
+
+  // game state の変化を localStorage に保存
+  useEffect(() => {
+    if (!game) return;
+    saveState(game);
+  }, [game]);
+
+  // タブ復帰時に接続が切れていれば再接続を試みる
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      if (role === "host") {
+        hostRef.current?.tryReconnect();
+      } else {
+        guestRef.current?.tryReconnect().then(() => {
+          // 再接続で状態が同期されればエラー表示をクリア
+          setError("");
+        });
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [role]);
 
   // ゲストが同期を受けたら局番号を更新
   useEffect(() => {
@@ -174,16 +211,33 @@ function GameContent() {
   };
 
   if (error) {
+    const handleReconnect = async () => {
+      if (role === "host") {
+        hostRef.current?.tryReconnect();
+        setError("");
+      } else {
+        await guestRef.current?.tryReconnect();
+        setError("");
+      }
+    };
     return (
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="text-center space-y-4">
           <p className="text-red-600 dark:text-red-400">{error}</p>
-          <button
-            onClick={() => router.push("/")}
-            className="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium dark:bg-gray-800"
-          >
-            トップに戻る
-          </button>
+          <div className="flex justify-center gap-2">
+            <button
+              onClick={handleReconnect}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+            >
+              再接続
+            </button>
+            <button
+              onClick={() => router.push("/")}
+              className="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium dark:bg-gray-800"
+            >
+              トップに戻る
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -53,6 +53,13 @@ export function addRound(
   kyotakuAfter: number,
   riichiSeats: number[] = [],
 ): GameState {
+  // 冪等性: 同じ (roundNum, honba) が既にあれば追加しない
+  // 複数端末から同時に同じ局が送信されたときの重複を防ぐ
+  const exists = state.rounds.some(
+    (r) => r.roundNum === roundNum && r.honba === honba,
+  );
+  if (exists) return state;
+
   const roundScores = state.players.map((p, i) => ({
     seat: p.seat,
     points: scores[i],
@@ -95,4 +102,38 @@ export function generateRoomId(): string {
     id += chars[Math.floor(Math.random() * chars.length)];
   }
   return id;
+}
+
+// localStorage 永続化
+const STORAGE_PREFIX = "jancal:state:";
+
+export function saveState(state: GameState): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_PREFIX + state.roomId, JSON.stringify(state));
+  } catch {
+    // quota超過などは握り潰す
+  }
+}
+
+export function loadState(roomId: string): GameState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + roomId);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as GameState;
+    if (parsed.roomId !== roomId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearState(roomId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + roomId);
+  } catch {
+    // noop
+  }
 }

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -40,6 +40,21 @@ export class RoomHost {
     this.callbacks = callbacks;
   }
 
+  isOpen(): boolean {
+    return !!this.peer && !this.peer.disconnected && !this.peer.destroyed;
+  }
+
+  // 一時的に切断されている場合にシグナリングサーバーへ再接続を試みる
+  tryReconnect(): void {
+    if (this.peer && this.peer.disconnected && !this.peer.destroyed) {
+      try {
+        this.peer.reconnect();
+      } catch {
+        // noop
+      }
+    }
+  }
+
   async create(roomId: string): Promise<void> {
     return new Promise((resolve, reject) => {
       this.peer = new Peer(PEER_PREFIX + roomId);
@@ -100,12 +115,19 @@ export class RoomGuest {
   private peer: Peer | null = null;
   private connection: DataConnection | null = null;
   private callbacks: PeerCallbacks;
+  private roomId: string | null = null;
+  private reconnecting = false;
 
   constructor(callbacks: PeerCallbacks) {
     this.callbacks = callbacks;
   }
 
+  isOpen(): boolean {
+    return !!this.connection && this.connection.open;
+  }
+
   async join(roomId: string): Promise<void> {
+    this.roomId = roomId;
     return new Promise((resolve, reject) => {
       this.peer = new Peer();
 
@@ -148,6 +170,23 @@ export class RoomGuest {
     });
   }
 
+  // バックグラウンド復帰時の再接続
+  async tryReconnect(): Promise<void> {
+    if (this.isOpen() || this.reconnecting || !this.roomId) return;
+    this.reconnecting = true;
+    try {
+      // 既存のpeerは破棄して新しく作り直す
+      this.peer?.destroy();
+      this.peer = null;
+      this.connection = null;
+      await this.join(this.roomId);
+    } catch {
+      // 失敗時は次の機会に再試行
+    } finally {
+      this.reconnecting = false;
+    }
+  }
+
   sendAction(action: GameAction): void {
     if (this.connection?.open) {
       this.connection.send({
@@ -161,5 +200,6 @@ export class RoomGuest {
     this.peer?.destroy();
     this.peer = null;
     this.connection = null;
+    this.roomId = null;
   }
 }


### PR DESCRIPTION
- localStorageでゲーム状態を永続化し、ブラウザ再読込でも復元可能に
- addRoundに冪等性を持たせ、同一(局, 本場)の重複追加を防止
- visibilitychange/focusで切断時の自動再接続、エラー時は再接続ボタンを表示