### PR TITLE
Feat/multi-hanchan

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -9,6 +9,7 @@ import {
   addRound,
   deleteLastRound,
   finishGame,
+  startNewHanchan,
   getCurrentPoints,
   saveState,
   loadState,
@@ -72,6 +73,9 @@ function GameContent() {
             break;
           case "finish-game":
             next = finishGame(prev);
+            break;
+          case "start-new-hanchan":
+            next = startNewHanchan(prev, action.finalPoints, action.finalScores);
             break;
           default:
             return prev;
@@ -184,6 +188,7 @@ function GameContent() {
   // - 親アガリ・流局親テンパイ: 局そのまま、本場+1
   // - 子アガリ: 局+1、本場リセット
   // - 流局親ノーテン: 局+1、本場+1
+  // 新しい半荘の開始時（rounds=[]）は東1局・0本場にリセット
   useEffect(() => {
     if (!game) return;
     if (game.rounds.length > 0) {
@@ -192,6 +197,9 @@ function GameContent() {
       const reset = lastRound.resetHonba ?? true;
       setRoundNum(continues ? lastRound.roundNum : lastRound.roundNum + 1);
       setHonba(reset ? 0 : lastRound.honba + 1);
+    } else {
+      setRoundNum(0);
+      setHonba(0);
     }
   }, [game?.rounds.length]);
 
@@ -235,6 +243,27 @@ function GameContent() {
 
   const handleFinishGame = () => {
     const action: GameAction = { type: "finish-game" };
+    if (role === "host") {
+      handleAction(action);
+    } else {
+      guestRef.current?.sendAction(action);
+    }
+  };
+
+  const handleStartNewHanchan = () => {
+    if (!game || game.status !== "finished") return;
+    const finalPoints = getCurrentPoints(game);
+    const finalScores = calcFinalScores(
+      finalPoints,
+      game.initialPoints,
+      game.returnPoints,
+      game.playerCount,
+    );
+    const action: GameAction = {
+      type: "start-new-hanchan",
+      finalPoints,
+      finalScores,
+    };
     if (role === "host") {
       handleAction(action);
     } else {
@@ -302,6 +331,25 @@ function GameContent() {
 
   const gridCols = pc === 3 ? "grid-cols-3" : "grid-cols-4";
 
+  const pastHanchans = game.pastHanchans ?? [];
+  const hanchanNumber = pastHanchans.length + 1;
+  // 通算スコア: 過去半荘 + 現在の半荘（終了時のみ加算）
+  const cumulativeScores: number[] | null = (() => {
+    if (pastHanchans.length === 0 && game.status !== "finished") return null;
+    const sum = new Array(pc).fill(0);
+    for (const h of pastHanchans) {
+      h.finalScores.forEach((s, i) => {
+        sum[i] += s;
+      });
+    }
+    if (game.status === "finished" && finalScores) {
+      finalScores.forEach((s, i) => {
+        sum[i] += s;
+      });
+    }
+    return sum;
+  })();
+
   return (
     <div className="mx-auto w-full max-w-lg p-4 space-y-4">
       {/* ヘッダー */}
@@ -323,6 +371,11 @@ function GameContent() {
           <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
             {pc}人麻雀
           </span>
+          {(pastHanchans.length > 0 || hanchanNumber > 1) && (
+            <span className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-300">
+              {hanchanNumber}半荘目
+            </span>
+          )}
           {role === "host" && (
             <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
               {connectionCount}人接続
@@ -397,6 +450,16 @@ function GameContent() {
         </div>
       )}
 
+      {/* 終了後のアクション: 新しい半荘を始める */}
+      {game.status === "finished" && (
+        <button
+          onClick={handleStartNewHanchan}
+          className="w-full rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-700"
+        >
+          新しい半荘を始める
+        </button>
+      )}
+
       {/* スコア入力モーダル */}
       {showScoreInput && (
         <ScoreInputModal
@@ -413,11 +476,80 @@ function GameContent() {
         />
       )}
 
+      {/* 通算スコア（複数半荘プレイ時） */}
+      {cumulativeScores && pastHanchans.length > 0 && (
+        <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-900">
+          <h3 className="mb-3 text-sm font-semibold text-gray-500 dark:text-gray-400">
+            通算スコア（{pastHanchans.length + (game.status === "finished" ? 1 : 0)}半荘）
+          </h3>
+          <div className={`grid ${gridCols} gap-2`}>
+            {game.players.map((player, i) => (
+              <div key={player.seat} className="text-center">
+                <div className="text-xs text-gray-500 truncate">{player.name}</div>
+                <div
+                  className={`text-lg font-bold tabular-nums ${
+                    cumulativeScores[i] >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-red-600 dark:text-red-400"
+                  }`}
+                >
+                  {cumulativeScores[i] > 0 ? "+" : ""}
+                  {cumulativeScores[i].toFixed(1)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 過去の半荘の結果 */}
+      {pastHanchans.length > 0 && (
+        <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-900">
+          <h3 className="mb-3 text-sm font-semibold text-gray-500 dark:text-gray-400">
+            半荘ごとの結果
+          </h3>
+          <div className="space-y-2">
+            {pastHanchans.map((h, idx) => (
+              <div
+                key={idx}
+                className="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800"
+              >
+                <div className="mb-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+                  半荘{idx + 1}
+                </div>
+                <div className={`grid ${gridCols} gap-2`}>
+                  {game.players.map((player, i) => (
+                    <div key={player.seat} className="text-center">
+                      <div className="text-[10px] text-gray-500 truncate">
+                        {player.name}
+                      </div>
+                      <div
+                        className={`text-sm font-semibold tabular-nums ${
+                          h.finalScores[i] >= 0
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-red-600 dark:text-red-400"
+                        }`}
+                      >
+                        {h.finalScores[i] > 0 ? "+" : ""}
+                        {h.finalScores[i].toFixed(1)}
+                      </div>
+                      <div className="text-[10px] text-gray-400 tabular-nums">
+                        {h.finalPoints[i].toLocaleString()}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* ラウンド履歴 */}
       {game.rounds.length > 0 && (
         <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-900">
           <h3 className="mb-3 text-sm font-semibold text-gray-500 dark:text-gray-400">
-            局履歴
+            {pastHanchans.length > 0 ? `半荘${hanchanNumber} 局履歴` : "局履歴"}
           </h3>
           <div className="space-y-2">
             {[...game.rounds].reverse().map((round, reverseIdx) => {

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -9,6 +9,7 @@ import {
   addRound,
   deleteLastRound,
   finishGame,
+  swapPlayers,
   getCurrentPoints,
   saveState,
   loadState,
@@ -16,6 +17,7 @@ import {
 import { RoomHost, RoomGuest, type GameAction, type PeerRole } from "@/lib/peer";
 import { saveLastRoom } from "@/lib/prefs";
 import ScoreInputModal from "@/components/ScoreInputModal";
+import SwapPlayersModal from "@/components/SwapPlayersModal";
 
 function GameContent() {
   const searchParams = useSearchParams();
@@ -26,6 +28,7 @@ function GameContent() {
 
   const [game, setGame] = useState<GameState | null>(null);
   const [showScoreInput, setShowScoreInput] = useState(false);
+  const [showSwapPlayers, setShowSwapPlayers] = useState(false);
   const [roundNum, setRoundNum] = useState(0);
   const [honba, setHonba] = useState(0);
   const [submitting, setSubmitting] = useState(false);
@@ -72,6 +75,9 @@ function GameContent() {
             break;
           case "finish-game":
             next = finishGame(prev);
+            break;
+          case "swap-players":
+            next = swapPlayers(prev, action.seatA, action.seatB);
             break;
           default:
             return prev;
@@ -242,6 +248,16 @@ function GameContent() {
     }
   };
 
+  const handleSwapPlayers = (seatA: number, seatB: number) => {
+    const action: GameAction = { type: "swap-players", seatA, seatB };
+    if (role === "host") {
+      handleAction(action);
+    } else {
+      guestRef.current?.sendAction(action);
+    }
+    setShowSwapPlayers(false);
+  };
+
   const handleCopyInvite = async () => {
     const base = window.location.origin + (process.env.NEXT_PUBLIC_BASE_PATH || "");
     const url = `${base}/game?room=${roomId}&role=guest`;
@@ -389,12 +405,29 @@ function GameContent() {
             スコア入力
           </button>
           <button
+            onClick={() => setShowSwapPlayers(true)}
+            className="rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            title="プレイヤーを入れ替え"
+          >
+            席替え
+          </button>
+          <button
             onClick={handleFinishGame}
             className="rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
           >
             終了
           </button>
         </div>
+      )}
+
+      {/* プレイヤー入れ替えモーダル */}
+      {showSwapPlayers && (
+        <SwapPlayersModal
+          players={game.players}
+          windLabels={windLabels}
+          onSwap={handleSwapPlayers}
+          onClose={() => setShowSwapPlayers(false)}
+        />
       )}
 
       {/* スコア入力モーダル */}

--- a/src/components/SwapPlayersModal.tsx
+++ b/src/components/SwapPlayersModal.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { type Player } from "@/lib/gameState";
+
+type Props = {
+  players: Player[];
+  windLabels: string[];
+  onSwap: (seatA: number, seatB: number) => void;
+  onClose: () => void;
+};
+
+export default function SwapPlayersModal({
+  players,
+  windLabels,
+  onSwap,
+  onClose,
+}: Props) {
+  const [seatA, setSeatA] = useState<number | null>(null);
+  const [seatB, setSeatB] = useState<number | null>(null);
+
+  const canSwap = seatA !== null && seatB !== null && seatA !== seatB;
+
+  const handleSelect = (seat: number) => {
+    if (seatA === seat) {
+      setSeatA(null);
+      return;
+    }
+    if (seatB === seat) {
+      setSeatB(null);
+      return;
+    }
+    if (seatA === null) {
+      setSeatA(seat);
+    } else if (seatB === null) {
+      setSeatB(seat);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (canSwap) onSwap(seatA!, seatB!);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center">
+      <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg dark:bg-gray-900">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold">プレイヤー入れ替え</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+          >
+            ✕
+          </button>
+        </div>
+        <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+          入れ替える2人を選択してください。点数履歴は席に紐づいたまま残ります。
+        </p>
+        <div className="space-y-2">
+          {players.map((p) => {
+            const isA = seatA === p.seat;
+            const isB = seatB === p.seat;
+            const selected = isA || isB;
+            const order = isA ? 1 : isB ? 2 : null;
+            return (
+              <button
+                key={p.seat}
+                onClick={() => handleSelect(p.seat)}
+                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
+                  selected
+                    ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/60 dark:text-emerald-100"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                }`}
+              >
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                    selected
+                      ? "bg-emerald-600 text-white"
+                      : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+                  }`}
+                >
+                  {windLabels[p.seat]}
+                </span>
+                <span className="flex-1 truncate">{p.name}</span>
+                {order && (
+                  <span className="rounded-full bg-emerald-600 px-2 py-0.5 text-xs font-bold text-white">
+                    {order}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          onClick={handleSubmit}
+          disabled={!canSwap}
+          className="mt-4 w-full rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+        >
+          入れ替える
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -88,6 +88,23 @@ export function deleteLastRound(state: GameState): GameState {
   };
 }
 
+// 2席のプレイヤー名を入れ替える。点数履歴は席に紐づいたまま残る。
+export function swapPlayers(
+  state: GameState,
+  seatA: number,
+  seatB: number,
+): GameState {
+  if (seatA === seatB) return state;
+  const idxA = state.players.findIndex((p) => p.seat === seatA);
+  const idxB = state.players.findIndex((p) => p.seat === seatB);
+  if (idxA === -1 || idxB === -1) return state;
+  const players = state.players.map((p) => ({ ...p }));
+  const tmp = players[idxA].name;
+  players[idxA].name = players[idxB].name;
+  players[idxB].name = tmp;
+  return { ...state, players };
+}
+
 export function finishGame(state: GameState): GameState {
   return { ...state, status: "finished" };
 }

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -19,6 +19,15 @@ export type Round = {
   resetHonba?: boolean;
 };
 
+export type Hanchan = {
+  rounds: Round[];
+  // 各席の最終持ち点（席番号順）
+  finalPoints: number[];
+  // ウマ・オカ適用後の最終スコア（席番号順）
+  finalScores: number[];
+  finishedAt: number;
+};
+
 export type GameState = {
   roomId: string;
   status: "waiting" | "active" | "finished";
@@ -28,6 +37,8 @@ export type GameState = {
   kyotaku: number;
   players: Player[];
   rounds: Round[];
+  // 完了した過去の半荘（古い順）
+  pastHanchans?: Hanchan[];
 };
 
 export function createInitialState(
@@ -90,6 +101,28 @@ export function deleteLastRound(state: GameState): GameState {
 
 export function finishGame(state: GameState): GameState {
   return { ...state, status: "finished" };
+}
+
+// 現在の半荘を過去の半荘に格納し、新しい半荘を開始する
+export function startNewHanchan(
+  state: GameState,
+  finalPoints: number[],
+  finalScores: number[],
+): GameState {
+  if (state.status !== "finished") return state;
+  const past: Hanchan = {
+    rounds: state.rounds,
+    finalPoints,
+    finalScores,
+    finishedAt: Date.now(),
+  };
+  return {
+    ...state,
+    status: "active",
+    kyotaku: 0,
+    rounds: [],
+    pastHanchans: [...(state.pastHanchans ?? []), past],
+  };
 }
 
 // 各プレイヤーの現在の持ち点を計算

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -24,7 +24,12 @@ export type GameAction =
       resetHonba: boolean;
     }
   | { type: "delete-last-round" }
-  | { type: "finish-game" };
+  | { type: "finish-game" }
+  | {
+      type: "start-new-hanchan";
+      finalPoints: number[];
+      finalScores: number[];
+    };
 
 export type PeerCallbacks = {
   onStateUpdate: (state: GameState) => void;

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -24,7 +24,8 @@ export type GameAction =
       resetHonba: boolean;
     }
   | { type: "delete-last-round" }
-  | { type: "finish-game" };
+  | { type: "finish-game" }
+  | { type: "swap-players"; seatA: number; seatB: number };
 
 export type PeerCallbacks = {
   onStateUpdate: (state: GameState) => void;


### PR DESCRIPTION
GameState に pastHanchans を追加し、終了後に「新しい半荘を始める」アクションで現在の半荘をアーカイブして新規半荘を開始できるようにした。過去の半荘ごとの最終スコア・最終持ち点と、全半荘の通算スコアをゲーム画面に表示する。